### PR TITLE
Fix: Cloud Storage authentication code returned in URL but not displayed (EVF-2743)

### DIFF
--- a/includes/class-everest-forms.php
+++ b/includes/class-everest-forms.php
@@ -187,6 +187,7 @@ final class EverestForms {
 		add_action( 'switch_blog', array( $this, 'wpdb_table_fix' ), 0 );
 		add_filter( 'everest_forms_entry_bulk_actions', array( $this, 'everest_forms_entry_bulk_actions' ) );
 		add_action( 'init', array( $this, 'evf_register_inactive_post_status' ) );
+		add_action( 'init', array( $this, 'maybe_load_integrations_for_oauth' ), 5 );
 	}
 
 	/**
@@ -433,7 +434,34 @@ final class EverestForms {
 		do_action( 'everest_forms_init' );
 	}
 
+	/**
+	 * Load integrations early when the request is an OAuth callback.
+	 *
+	 * Integrations are otherwise lazily loaded on `current_screen`, and only on
+	 * Everest Forms admin screens. Providers register their callback handlers in
+	 * their constructors on hooks that fire before that (`template_redirect` for
+	 * Google Drive/Sheets/Calendar, `admin_init` for OneDrive), so without this
+	 * the access code returned by the provider is never picked up.
+	 *
+	 * @since 3.5.4
+	 */
+	public function maybe_load_integrations_for_oauth() {
+		if ( $this->integrations ) {
+			return;
+		}
 
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		// Google redirects back to home_url() with ?code=...&scope=..., OneDrive to admin_url( '?evf_onedrive_auth=1' ).
+		$is_google_callback   = ! empty( $_GET['code'] ) && ! empty( $_GET['scope'] );
+		$is_onedrive_callback = isset( $_GET['evf_onedrive_auth'] );
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		if ( ! $is_google_callback && ! $is_onedrive_callback ) {
+			return;
+		}
+
+		$this->integrations = new EVF_Integrations();
+	}
 
 	/**
 	 * Setup objects.


### PR DESCRIPTION
## Problem

[EVF-2743](https://themegrill.atlassian.net/browse/EVF-2743) — after completing Google authentication, the browser is redirected back to the site with the OAuth `code` in the URL, but Everest Forms never displays it, so the user has nothing to paste into **Verify Access Code**. The user is left on the redirected page.

Reported for **both Google Drive and OneDrive**, which was the key clue — the defect is in the shared loading path, not in any one provider.

## Root cause

Integrations are lazily constructed in `EVF_Admin::maybe_load_integrations()`, which runs on `current_screen` and only when the screen is in `evf_get_screen_ids()`. `class-evf-admin.php` is itself only included for admin requests.

Providers register their OAuth callback handlers **in their constructors**, on hooks that are never reached under that gating:

| Provider | Redirect URI | Handler hook | Why it never runs |
|---|---|---|---|
| Google Drive | `home_url()` | `template_redirect` | Front-end request → `EVF_Integrations` is never constructed → hook never registered. The callback lands on the home page, which renders normally. |
| OneDrive | `admin_url( '?evf_onedrive_auth=1' )` | `admin_init` | Screen is `dashboard`, not in `evf_get_screen_ids()`. And `admin_init` fires *before* `current_screen`, so the handler would register too late even on an EVF screen. |

Google Sheets and Google Calendar have the same `template_redirect` shape and were broken identically. Dropbox is unaffected because Dropbox shows the code on its own page — which is why Dropbox is the one provider that still connects.

Regression introduced in d9a2894d, first shipped in **3.4.7**. The earlier narrow patch 131e2669 ("integration disconnect AJAX handler not registering provider hooks") was the same root cause surfacing on the AJAX path.

## Fix

One hook, covering all four providers: `maybe_load_integrations_for_oauth()` on `init` priority 5, which constructs `EVF_Integrations` only when the request carries an OAuth callback signature (`code` + `scope` for Google, `evf_onedrive_auth` for OneDrive).

Priority 5 is deliberate — it lands after `EverestForms::init()` (priority 0) has fired `everest_forms_init`, where the cloud storage `Service` registers itself, and before both `template_redirect` and `admin_init`.

Ordinary requests are unaffected, so the lazy-loading intent is preserved.

## Testing

Verified against a local site, toggling the new hook off and back on to isolate cause.

**Google Drive, over HTTP:**

| Request | Before | After |
|---|---|---|
| `?code=X&scope=…drive.file` | front page (bug reproduced) | token page with code ✅ |
| `?iss=…&code=X&scope=…drive.file openid email` | front page | token page with code ✅ |
| `?code=X&scope=…spreadsheets` | — | correctly not handled ✅ |
| `?code=X` (no scope) | — | correctly not handled ✅ |
| plain `/` | front page | front page, unchanged ✅ |

**OneDrive** — booted WP with a simulated `/wp-admin/?evf_onedrive_auth=1&code=…` request and inspected the hook registry:

```
integrations_loaded          yes
loaded_integration_ids       dropbox, google_drive, google_calendar, activecampaign,
                             clean-talk, onedrive, amazon_s3, geolocation
onedrive_token_page_hooked   yes (priority 10, OneDrive_Integration)
admin_init_already_fired     no (good)
```

**Negative control** — ordinary `/wp-admin/` request: `integrations_loaded NO`. Nothing extra loads on normal page views.

## Related

Requires wpeverest/everest-forms-pro#1198, which fixes a second, independent defect in `GoogleDrive::google_drive_token_page()` (the granted-scope guard used exact string equality, so any extra granted scope also broke the token page). **Both must be merged for the Google Drive flow to work end to end.** The OneDrive flow is fixed by this PR alone.

## Notes

- `@since` on the new method is tagged `3.5.4` (current is 3.5.3) — adjust if the next release number differs.
- The same brittle exact-match scope check also exists in the Google Sheets addon and `GoogleCalendar.php`. This PR unbreaks both, but they will re-break the same way if Google ever widens the granted scope — worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[EVF-2743]: https://themegrill.atlassian.net/browse/EVF-2743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ