### PR TITLE
Fix: form attachment not sent to all recipients (EVF-2750)

### DIFF
--- a/includes/class-evf-form-task.php
+++ b/includes/class-evf-form-task.php
@@ -1391,6 +1391,9 @@ class EVF_Form_Task {
 
 		$notifications = isset( $form_data['settings']['email'] ) ? $form_data['settings']['email'] : array();
 
+		// Connections whose attachments still need cleaning up once every notification is sent.
+		$cleanup_connections = array();
+
 		foreach ( $notifications as $connection_id => $notification ) :
 
 			// Don't proceed if email notification is not enabled.
@@ -1455,10 +1458,20 @@ class EVF_Form_Task {
 				$emails->send( trim( $address ), $email['subject'], $email['message'], '', $connection_id );
 			}
 
-			if ( isset( $attachment ) ) {
-				do_action( 'everest_forms_remove_attachments_after_send_email', $attachment, $fields, $form_data, 'entry-email', $connection_id, $entry_id );
-			}
+			$cleanup_connections[] = $connection_id;
 			endforeach;
+
+		/*
+		 * Clean up the attachment files only after every notification has been sent.
+		 * Cleaning up inside the loop deletes the uploaded files (when entry storage is
+		 * disabled) and the generated CSV while later notifications are still pending,
+		 * so those notifications go out without their attachments.
+		 */
+		if ( isset( $attachment ) ) {
+			foreach ( $cleanup_connections as $cleanup_connection_id ) {
+				do_action( 'everest_forms_remove_attachments_after_send_email', $attachment, $fields, $form_data, 'entry-email', $cleanup_connection_id, $entry_id );
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Problem

Reported by an Agency-plan customer (free 3.6.0 + pro 1.9.20): with **multiple email recipients/notifications**, the uploaded file is not attached to the email. With a single recipient it works. They correlate the onset with **3.5.2**.

## Root cause

`EVF_Form_Task::entry_email()` fires `everest_forms_remove_attachments_after_send_email` **inside** the notification loop, so cleanup runs *between* notifications rather than after all of them. This was moved into the loop by 4581c507 ("fix:file csv attachment issue"), which matches the version the customer reported.

The handler, `EVF_Form_Fields_Upload::remove_csv_file_after_email_send()`, unlinks the submission's uploaded files whenever entry storage is disabled (`settings.disabled_entries === '1'`), and always deletes the generated entry CSV. So:

1. Notification 1 resolves its attachments — files still on disk — and sends fine.
2. Cleanup fires and deletes the files.
3. Notification 2+ resolve their attachments after the files are gone → mail is sent, silently without the attachment.

If the *first* notification is one without "Send File As Attachment" (e.g. an auto-reply to the submitter), the files are deleted before the notification that wants them, so **no recipient** gets the file — the customer's exact report.

This only reproduces on forms with **entry storage disabled**. Forms that store entries resolve attachments from the DB and never hit the unlink path, which is why a freshly created form doesn't reproduce it.

## Fix

Collect the processed connection ids and fire the cleanup action once per connection **after** the loop, so every notification is sent before anything is deleted. The hook still fires per connection with an unchanged payload, so existing handlers keep working.

## Verification

Real submissions on a form with entry storage disabled and two enabled notifications, both with "Send File As Attachment", checked in the mail catcher:

| | before | after |
|---|---|---|
| Notification 1 | file attached | file attached |
| Notification 2 | **no attachment** | file attached |

Cleanup still happens: with entry storage disabled the uploaded file is gone from `uploads/everest_forms_uploads/<form>/` after the request, and the generated CSV is removed — the deletion is deferred, not skipped.

Regression cases, same method:

- Entry storage **enabled**, 2 notifications, file + CSV attachments on both → both emails carry both attachments; **identical before and after**; uploaded file correctly kept on disk for the entry view.
- Entry storage **disabled**, single notification → file delivered, file cleaned up.
- Notification disabled (skipped by `continue`) → no cleanup fired for it, as before.
- No new warnings/notices/fatals in the PHP or EVF logs across all runs.

## Notes / out of scope

Two pre-existing issues found while investigating, both unchanged by this PR and worth separate tickets:

- With entry storage disabled, **CSV attachment never works** — `csv_entry_files()` needs an entry id and there isn't one, so the toggle silently does nothing.
- The same cleanup handler deletes uploaded files during `entry_email()`, i.e. **before** `everest_forms_process_complete`, so integrations that upload the file (Salesforce, Zapier, Google Sheets, PDF) can't see it on entry-storage-disabled forms.

No changelog entry included — the current top section is the released `3.6.0` and I didn't want to guess the next version. Happy to add one on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)