### PR TITLE
fix(entries): respect saved column order in Manage Columns

### DIFF
--- a/includes/admin/class-evf-admin-entries-table-list.php
+++ b/includes/admin/class-evf-admin-entries-table-list.php
@@ -180,17 +180,6 @@ class EVF_Admin_Entries_Table_List extends EVF_Base_List_Table {
 				}
 			}
 		} elseif ( ! empty( $entry_columns ) ) {
-			$key = array_search( 'sn', $entry_columns, true );
-			if ( false !== $key ) {
-				unset( $entry_columns[ $key ] );
-				$entry_columns = array_merge( array( 'sn' ), $entry_columns );
-			}
-
-			$key = array_search( 'id', $entry_columns, true );
-			if ( false !== $key ) {
-				unset( $entry_columns[ $key ] );
-				$entry_columns = array_merge( array( 'id' ), $entry_columns );
-			}
 			foreach ( $entry_columns as $id ) {
 				// Check to make sure the field as not been removed.
 				$status = defined( 'EFP_VERSION' ) ? true : false;


### PR DESCRIPTION
## Problem
Entries table always pinned S.N. and Entry ID to the front of the columns on render, silently discarding any reorder of those two columns done via Manage Columns.

Fixes EVF-2116.

## Changes
- Removed the front-pinning logic in `get_columns_form_fields()`; the render now follows the saved column order as-is.

## Testing
- Verified live: dragging S.N./Entry ID to a custom position and saving now persists that position on render.
- Verified live: explicitly hiding S.N./Entry ID via Manage Columns and saving now stays hidden (previously this regressed back to always-visible-at-front).

## Related
Pairs with wpeverest/everest-forms-pro#1201 (save-side duplicate-label fix).