### PR TITLE
Fix image field value getting cleared when self-request fails

### DIFF
--- a/includes/admin/evf-admin-functions.php
+++ b/includes/admin/evf-admin-functions.php
@@ -557,18 +557,28 @@ function everest_forms_panel_field($option, $panel, $field, $form_data, $label, 
 			$output .= '</div>';
 			break;
 		case 'image':
-			if ('' !== $value) {
-				$headers = get_headers($value, 1);
+			if ( '' !== $value ) {
+				$upload_dir = wp_upload_dir();
+				$local_path = str_replace( $upload_dir['baseurl'], $upload_dir['basedir'], $value );
 
-				// Only clear the value when the URL responds and clearly isn't an image.
-				// A failed/blocked request (e.g. outbound requests disabled or a firewall
-				// intercepting the site calling back into itself) must not wipe out an
-				// otherwise valid, previously saved image.
-				if (is_array($headers)) {
-					$content_type = is_array($headers['Content-Type']) ? implode(' ', $headers['Content-Type']) : $headers['Content-Type'];
+				if ( file_exists( $local_path ) ) {
+					$file_type = wp_check_filetype( $local_path );
 
-					if (strpos($content_type, 'image/') === false) {
+					if ( 0 !== strpos( (string) $file_type['type'], 'image/' ) ) {
 						$value = '';
+					}
+				} else {
+					$response = wp_remote_head( $value );
+
+					// Only a 2xx response is evidence about the resource; a blocked, timed out or
+					// intercepted request must not wipe an already saved image.
+					if ( ! is_wp_error( $response ) && 200 === wp_remote_retrieve_response_code( $response ) ) {
+						$content_type = wp_remote_retrieve_header( $response, 'content-type' );
+						$content_type = is_array( $content_type ) ? implode( ' ', $content_type ) : (string) $content_type;
+
+						if ( '' !== $content_type && false === strpos( $content_type, 'image/' ) ) {
+							$value = '';
+						}
 					}
 				}
 			}

--- a/includes/admin/evf-admin-functions.php
+++ b/includes/admin/evf-admin-functions.php
@@ -558,11 +558,18 @@ function everest_forms_panel_field($option, $panel, $field, $form_data, $label, 
 			break;
 		case 'image':
 			if ('' !== $value) {
-				$headers      = get_headers($value, 1);
-				$content_type = is_array($headers['Content-Type']) ? implode(' ', $headers['Content-Type']) : $headers['Content-Type'];
+				$headers = get_headers($value, 1);
 
-				if (strpos($content_type, 'image/') === false) {
-					$value = '';
+				// Only clear the value when the URL responds and clearly isn't an image.
+				// A failed/blocked request (e.g. outbound requests disabled or a firewall
+				// intercepting the site calling back into itself) must not wipe out an
+				// otherwise valid, previously saved image.
+				if (is_array($headers)) {
+					$content_type = is_array($headers['Content-Type']) ? implode(' ', $headers['Content-Type']) : $headers['Content-Type'];
+
+					if (strpos($content_type, 'image/') === false) {
+						$value = '';
+					}
 				}
 			}
 


### PR DESCRIPTION
## Summary
- `everest_forms_panel_field()`'s `image` case re-validates the stored URL on every render by calling `get_headers()` against it, and blanked the value whenever that call didn't come back as an image - including when the request itself failed (e.g. outbound requests blocked, a firewall intercepting the site calling back into itself, DNS/SSL hiccups on that environment).
- This manifests as a saved header/footer logo (in the PDF Submission addon's per-form settings, but same field type is used elsewhere) disappearing right after Save, since the panel re-renders with the fresh value immediately afterward.
- Fix: only clear the value when `get_headers()` actually returns a response and it's clearly not an image - not on any failure.

Ref: EVF-2751

## Test plan
- [ ] Set an image on an `image`-type panel field and save; confirm it persists across reloads
- [ ] Simulate the self-request failing (e.g. block outbound loopback requests) and confirm a previously saved image is no longer cleared