### PR TITLE
fix(security): restrict unserialize() in EVF_Form_Fields_Upload::html_field_value() (PHP Object Injection)

### DIFF
--- a/includes/abstracts/class-evf-form-fields-upload.php
+++ b/includes/abstracts/class-evf-form-fields-upload.php
@@ -783,6 +783,10 @@ abstract class EVF_Form_Fields_Upload extends EVF_Form_Fields {
 	 * @return string $val       Html Value.
 	 */
 	public function html_field_value( $val, $field_val, $form_data = array(), $context = '', $field_meta_key = '' ) {
+		if ( is_array( $field_meta_key ) && isset( $field_meta_key['type'] ) && $field_meta_key['type'] !== $this->type ) {
+			return $val;
+		}
+
 		$meta_key = '';
 		$entry_id = false;
 		$uploads  = wp_upload_dir();
@@ -923,7 +927,7 @@ abstract class EVF_Form_Fields_Upload extends EVF_Form_Fields {
 				$val = implode( 'export-csv' !== $context ? '<br>' : '|', $output[ $meta_key ] );
 			}
 		} elseif ( is_serialized( $field_val ) ) {
-			$value = maybe_unserialize( $field_val );
+			$value = evf_maybe_unserialize( $field_val );
 
 			if ( isset( $value['type'] ) && in_array( $value['type'], array( 'image-upload', 'file-upload' ), true ) ) {
 				$val = empty( $value['file_url'] ) ? '<em>' . esc_html__( '(empty)', 'everest-forms' ) . '</em>' : $val;


### PR DESCRIPTION
Fixes #1654

## Summary
Fixes a PHP Object Injection reported via Patchstack (report #34576, CVSS 9.8, unauthenticated).

`EVF_Form_Fields_Upload::html_field_value()` is hooked onto the generic `everest_forms_html_field_value` filter for **every** submitted field, and its serialized-value fallback called core `maybe_unserialize()` on raw, unauthenticated input with no `allowed_classes` restriction. A form containing a field whose type has no registered exporter (e.g. a Pro field left behind after a lapsed subscription) let an unauthenticated visitor instantiate any autoloadable class with attacker-chosen properties via the Ajax form-submission path — the same sink is reached a second time on every admin Entries page load via stored entry meta.

## Changes
- `includes/abstracts/class-evf-form-fields-upload.php`:
  - `maybe_unserialize($field_val)` → `evf_maybe_unserialize($field_val)`, the plugin's own helper which already enforces `allowed_classes => false`.
  - Added an early `return $val` in `html_field_value()` when the caller already told us the value belongs to a different field type than `$this->type`, so the callback stops touching data that was never an upload field's.

Both changes were called out explicitly in the report; the second reachable path (admin Entries) needed no separate change since it shares this same sink.

## Verification
- `php -l` passes on the modified file.
- Reproduced the exact Patchstack PoC payload (`ScssPhp\ScssPhp\Logger\StreamLogger` gadget) against this install's real `is_serialized()`/`maybe_unserialize()` and the plugin's real `evf_maybe_unserialize()`:
  - **Before**: nested payload element resolves to the real gadget class, its destructor runs, crashes with the exact `fclose(): Argument #1 ($stream) must be of type resource` TypeError from the report.
  - **After**: nested element resolves to `__PHP_Incomplete_Class`, destructor never fires, no crash.

## Test plan
- [ ] Import a form with a field type that has no registered exporter (e.g. a Pro field type with the corresponding addon deactivated), enable Ajax submission, and submit a serialized-looking payload for another field — confirm no object is instantiated and the request fails safely.
- [ ] Confirm normal file-upload/image-upload fields still render correctly in emails, the Entries table, and the single-entry view (regression check for the added type guard).
- [ ] View existing entries in wp-admin → Entries (table and single-entry view) to confirm no behavior change for non-upload field types.