### PR TITLE
Add Copilot review on comment

### DIFF
--- a/.github/workflows/copilot-review-on-comment.yml
+++ b/.github/workflows/copilot-review-on-comment.yml
@@ -1,0 +1,10 @@
+name: Copilot review on comment
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  review:
+    uses: wpeverest/.github/.github/workflows/copilot-review-on-comment.yml@master
+    secrets: inherit

--- a/.github/workflows/copilot-review-on-comment.yml
+++ b/.github/workflows/copilot-review-on-comment.yml
@@ -7,4 +7,5 @@ on:
 jobs:
   review:
     uses: wpeverest/.github/.github/workflows/copilot-review-on-comment.yml@master
-    secrets: inherit
+    secrets:
+      BOT_TOKEN: ${{ secrets.BOT_TOKEN }}


### PR DESCRIPTION
Adds the reusable Copilot-review-on-comment workflow, called from wpeverest/.github. Commenting `@tg-autopilot review` on a PR (from an account with write access or higher) requests a Copilot code review through tg-autopilot's seat.