### PR TITLE
Add PR build ZIP workflow

### DIFF
--- a/.github/workflows/pr-build-zip.yml
+++ b/.github/workflows/pr-build-zip.yml
@@ -21,7 +21,15 @@ jobs:
       # repo root already. This workflow's own install/composer steps would
       # just be redundant, wasted work duplicating what the script already
       # does, so they're skipped/no-op'd here rather than fighting it.
-      install-command: echo "Skipping -- bin/build-zip.sh installs its own JS deps"
+      # Can't skip this like composer-install: `npm run build` is literally
+      # `cross-env ./bin/build-zip.sh`, and cross-env has to already be
+      # resolvable from node_modules/.bin before that command can even
+      # start -- build-zip.sh's own internal npm install happens too late
+      # to help with that (confirmed for real: skipping this outright hit
+      # "cross-env: not found"). --legacy-peer-deps for the same reason as
+      # documented on the build-zip.sh fix -- @ajna/pagination's peer
+      # dependency conflict blocks a plain `npm ci` here too.
+      install-command: npm ci --legacy-peer-deps
       composer-install: false
       build-command: npm run build
       zip-glob: 'everest-forms.zip'

--- a/.github/workflows/pr-build-zip.yml
+++ b/.github/workflows/pr-build-zip.yml
@@ -11,7 +11,11 @@ jobs:
     uses: wpeverest/.github/.github/workflows/pr-build-zip.yml@master
     with:
       node-version: '20.x'
-      php-version: '7.4'
+      # composer.json declares ">=5.6.20" (an ancient, unmaintained floor --
+      # same pattern as user-registration-pro), but the actual composer.lock
+      # needs 8.2+ (phpspec/prophecy, webmozart/assert both require it).
+      # Confirmed for real: composer install fails outright on 7.4.
+      php-version: '8.2'
       package-manager: npm
       composer-install: true
       build-command: npm run build && mkdir -p everest-forms && rsync -rc --exclude-from=.distignore ./ ./everest-forms --delete --delete-excluded && zip -r everest-forms.zip everest-forms

--- a/.github/workflows/pr-build-zip.yml
+++ b/.github/workflows/pr-build-zip.yml
@@ -10,8 +10,8 @@ jobs:
   zip:
     uses: wpeverest/.github/.github/workflows/pr-build-zip.yml@master
     with:
-      node-version: '8.x'
-      php-version: '5.6'
+      node-version: '20.x'
+      php-version: '7.4'
       package-manager: npm
       composer-install: true
       build-command: npm run build
@@ -19,4 +19,7 @@ jobs:
       artifacts-bucket: themegrill-pr-artifacts
       public-base-url: https://themegrill-pr-artifacts.s3.amazonaws.com
       s3-region: us-east-1
-    secrets: inherit
+    secrets:
+      BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+      ARTIFACTS_KEY: ${{ secrets.ARTIFACTS_KEY }}
+      ARTIFACTS_SECRET: ${{ secrets.ARTIFACTS_SECRET }}

--- a/.github/workflows/pr-build-zip.yml
+++ b/.github/workflows/pr-build-zip.yml
@@ -11,24 +11,19 @@ jobs:
     uses: wpeverest/.github/.github/workflows/pr-build-zip.yml@master
     with:
       node-version: '20.x'
-      # composer.json declares ">=5.6.20" (an ancient, unmaintained floor --
-      # same pattern as user-registration-pro), but the actual composer.lock
-      # needs 8.2+ (phpspec/prophecy, webmozart/assert both require it).
-      # Confirmed for real: composer install fails outright on 7.4.
       php-version: '8.2'
       package-manager: npm
-      # @ajna/pagination@1.4.19 peer-requires react-scripts@5.0.1, which
-      # peer-requires an old TypeScript (^3.2.1 || ^4), but this project's
-      # own devDependency pins typescript@5.9.3 -- a genuine conflict in
-      # this repo's own dependency tree (confirmed via npm's ERESOLVE
-      # error), not something wrong with our build config. --legacy-peer-deps
-      # skips npm's strict peer-dependency check as a pragmatic workaround
-      # for a testable build; it does not fix the underlying conflict, so a
-      # real fix (dropping/replacing @ajna/pagination, or reconciling the
-      # TypeScript version) still belongs to this repo's own team.
-      install-command: npm ci --legacy-peer-deps
-      composer-install: true
-      build-command: npm run build && mkdir -p everest-forms && rsync -rc --exclude-from=.distignore ./ ./everest-forms --delete --delete-excluded && zip -r everest-forms.zip everest-forms
+      # `npm run build` runs this repo's own bin/build-zip.sh, which is a
+      # fully self-contained release script: it does its own
+      # `npm install --legacy-peer-deps`, its own `composer install` (with a
+      # PHP-version fix pending in a separate PR to that script), its own JS
+      # build, and its own rsync+zip -- producing everest-forms.zip at the
+      # repo root already. This workflow's own install/composer steps would
+      # just be redundant, wasted work duplicating what the script already
+      # does, so they're skipped/no-op'd here rather than fighting it.
+      install-command: echo "Skipping -- bin/build-zip.sh installs its own JS deps"
+      composer-install: false
+      build-command: npm run build
       zip-glob: 'everest-forms.zip'
       artifacts-bucket: themegrill-pr-artifacts
       public-base-url: https://themegrill-pr-artifacts.s3.amazonaws.com

--- a/.github/workflows/pr-build-zip.yml
+++ b/.github/workflows/pr-build-zip.yml
@@ -14,8 +14,8 @@ jobs:
       php-version: '7.4'
       package-manager: npm
       composer-install: true
-      build-command: npm run build
-      zip-glob: 'release/*.zip'
+      build-command: npm run build && mkdir -p everest-forms && rsync -rc --exclude-from=.distignore ./ ./everest-forms --delete --delete-excluded && zip -r everest-forms.zip everest-forms
+      zip-glob: 'everest-forms.zip'
       artifacts-bucket: themegrill-pr-artifacts
       public-base-url: https://themegrill-pr-artifacts.s3.amazonaws.com
       s3-region: us-east-1

--- a/.github/workflows/pr-build-zip.yml
+++ b/.github/workflows/pr-build-zip.yml
@@ -17,6 +17,16 @@ jobs:
       # Confirmed for real: composer install fails outright on 7.4.
       php-version: '8.2'
       package-manager: npm
+      # @ajna/pagination@1.4.19 peer-requires react-scripts@5.0.1, which
+      # peer-requires an old TypeScript (^3.2.1 || ^4), but this project's
+      # own devDependency pins typescript@5.9.3 -- a genuine conflict in
+      # this repo's own dependency tree (confirmed via npm's ERESOLVE
+      # error), not something wrong with our build config. --legacy-peer-deps
+      # skips npm's strict peer-dependency check as a pragmatic workaround
+      # for a testable build; it does not fix the underlying conflict, so a
+      # real fix (dropping/replacing @ajna/pagination, or reconciling the
+      # TypeScript version) still belongs to this repo's own team.
+      install-command: npm ci --legacy-peer-deps
       composer-install: true
       build-command: npm run build && mkdir -p everest-forms && rsync -rc --exclude-from=.distignore ./ ./everest-forms --delete --delete-excluded && zip -r everest-forms.zip everest-forms
       zip-glob: 'everest-forms.zip'

--- a/.github/workflows/pr-build-zip.yml
+++ b/.github/workflows/pr-build-zip.yml
@@ -1,0 +1,22 @@
+name: Build Testable ZIP
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [develop]
+  workflow_dispatch:
+
+jobs:
+  zip:
+    uses: wpeverest/.github/.github/workflows/pr-build-zip.yml@master
+    with:
+      node-version: '8.x'
+      php-version: '5.6'
+      package-manager: npm
+      composer-install: true
+      build-command: npm run build
+      zip-glob: 'release/*.zip'
+      artifacts-bucket: themegrill-pr-artifacts
+      public-base-url: https://themegrill-pr-artifacts.s3.amazonaws.com
+      s3-region: us-east-1
+    secrets: inherit


### PR DESCRIPTION
Adds a caller workflow for the reusable `pr-build-zip.yml` in wpeverest/.github.

On every PR (opened/synced/reopened/ready-for-review) this builds an installable plugin/theme ZIP and posts a download link as a PR comment, so a real ZIP is one click away from the code diff.

**The `build-command`, `package-manager`, and `zip-glob` below were auto-detected** from this repo's package.json/Gruntfile.js/gulpfile.js by an automated rollout script, not hand-written for this repo specifically. The first real PR opened against this branch is the actual test of whether the detected command produces a working ZIP in the expected place -- please double-check the `with:` block matches how this repo is actually packaged for release before relying on it, and adjust if the build fails.