### PR TITLE
fix: bin/build-zip.sh composer install --ignore-platform-reqs

### DIFF
--- a/bin/build-zip.sh
+++ b/bin/build-zip.sh
@@ -11,11 +11,19 @@ mkdir -p "$DEST_PATH"
 
 echo "Installing PHP and JS dependencies..."
 npm install --legacy-peer-deps || exit "$?"
-composer install || exit "$?"
+# --ignore-platform-reqs: composer.lock has dev-only packages (phpunit and
+# friends) locked to versions requiring old PHP, while the actual production
+# dependencies need a newer PHP -- no single installed PHP version can ever
+# satisfy both at once. Composer validates the whole lock file's platform
+# requirements up front regardless of which packages are actually going to
+# be installed, so this is needed on both calls below, not just the --no-dev
+# one, even though the first call still installs the dev packages that
+# trigger the conflict.
+composer install --ignore-platform-reqs || exit "$?"
 echo "Running JS Build..."
 npm run build:core || exit "$?"
 echo "Cleaning up PHP dependencies..."
-composer install --no-dev || exit "$?"
+composer install --no-dev --ignore-platform-reqs || exit "$?"
 
 echo "Syncing files..."
 rsync -rc --exclude-from="$PROJECT_PATH/.distignore" "$PROJECT_PATH/" "$DEST_PATH/" --delete --delete-excluded


### PR DESCRIPTION
## Problem

`composer.lock` has dev-only packages (`phpunit/phpunit`, `sebastian/global-state`, `spatie/phpunit-watcher`, etc.) locked to versions requiring old PHP (`^7.0`/`^7.1`), while the actual production dependencies need a newer PHP. No single installed PHP version can satisfy both constraints at once -- confirmed for real, this script's first `composer install` call fails outright in CI on PHP 8.2 (`Your lock file does not contain a compatible set of packages`).

Composer validates the **whole** lock file's platform requirements up front, regardless of which packages actually end up installed -- so this isn't specific to which packages get used, it blocks before that.

## Fix

Add `--ignore-platform-reqs` to both `composer install` calls. Safe here: this script never actually *runs* the dev-only tools it temporarily installs (no phpunit execution happens before the `--no-dev` cleanup pass strips them back out) -- it only needs the install itself to succeed.

## Test plan
- [ ] Merge
- [ ] Confirm the `pr-build-zip` CI check (wpeverest/.github's reusable workflow, which calls `npm run build` -> this script) now succeeds