### PR TITLE
Add PR review automation

### DIFF
--- a/.github/workflows/copilot-review-on-comment.yml
+++ b/.github/workflows/copilot-review-on-comment.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   review:
-    uses: wpeverest/.github/.github/workflows/copilot-review-on-comment.yml@master
+    uses: themegrill/.github/.github/workflows/copilot-review-on-comment.yml@master
     secrets:
       BOT_TOKEN: ${{ secrets.BOT_TOKEN }}


### PR DESCRIPTION
Adds the reusable PR-review workflow, called from themegrill/.github. It requests Copilot as a reviewer when a PR opens, and lets accounts with write access or higher request a Copilot review by commenting `@tg-autopilot review`.